### PR TITLE
Types - add location converter

### DIFF
--- a/src/main/java/ca/nylhus/skriptcitizens/classes/Types.java
+++ b/src/main/java/ca/nylhus/skriptcitizens/classes/Types.java
@@ -11,7 +11,7 @@ import ch.njol.util.coll.CollectionUtils;
 import net.citizensnpcs.api.event.DespawnReason;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
-import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -122,8 +122,8 @@ public class Types {
                 }));
 
         // CONVERTERS
-        // Enables the use of `location of %npc%`
-        Converters.registerConverter(NPC.class, Location.class, npc -> npc.getEntity().getLocation());
+        // Enables any Skript effect/expression that works for entities
+        Converters.registerConverter(NPC.class, Entity.class, NPC::getEntity);
     }
 
 }

--- a/src/main/java/ca/nylhus/skriptcitizens/classes/Types.java
+++ b/src/main/java/ca/nylhus/skriptcitizens/classes/Types.java
@@ -5,15 +5,17 @@ import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.lang.ParseContext;
 import ch.njol.skript.registrations.Classes;
-import ch.njol.util.coll.CollectionUtils;
+import ch.njol.skript.registrations.Converters;
 import ch.njol.skript.util.EnumUtils;
+import ch.njol.util.coll.CollectionUtils;
 import net.citizensnpcs.api.event.DespawnReason;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.Location;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"})
 public class Types {
 
     static {
@@ -118,6 +120,10 @@ public class Types {
                         return "npcdespawnreason:" + toString(despawnReason, 0);
                     }
                 }));
+
+        // CONVERTERS
+        // Enables the use of `location of %npc%`
+        Converters.registerConverter(NPC.class, Location.class, npc -> npc.getEntity().getLocation());
     }
 
 }


### PR DESCRIPTION
This PR aims to fix an issue with `location of %npc%`
I just added a simple NPC -> Entity converter, so location can be used.
Also allows any other Skript Effect/Condition/Expression for entities to work with NPCs